### PR TITLE
Add MiniMessage support (via Kyori/Adventure)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,17 +6,33 @@
     <groupId>net.shotbow</groupId>
     <artifactId>interestingfish</artifactId>
     <name>InterestingFish</name>
-    <version>1.16.2</version>
+    <!-- Follow Minecraft Versioning wth -${version} if needed -->
+    <version>1.16.3</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
+        <!-- Spigot-API - Needed for Plugin API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.2-R0.1-SNAPSHOT</version>
+            <version>1.16.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- Adventure-Platform-Bukkit - Needed for Hex Legacy Serialization -->
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bukkit</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Adventure-Text-MiniMessage - Needed for MiniMessage Text Formatting -->
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <repositories>
@@ -24,9 +40,14 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>sonatype-oss</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
     <build>
         <finalName>${project.name}</finalName>
+        <!-- Switch this to clean install if using deployment (such as CI) -->
         <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
@@ -38,10 +59,41 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <relocations>
+                        <relocation>
+                            <pattern>net.kyori.adventure</pattern>
+                            <shadedPattern>net.shotbow.interestingfish.lib.net.kyori.adventure</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net.kyori.examination</pattern>
+                            <shadedPattern>net.shotbow.interestingfish.lib.net.kyori.examination</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.checkerframework</pattern>
+                            <shadedPattern>net.shotbow.interestingfish.lib.org.checkerframework</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>
                 <filtering>true</filtering>
+                <!-- Dynamically fill in the plugin yaml with information from POM -->
                 <directory>src/main/resources</directory>
             </resource>
         </resources>

--- a/src/main/java/net/shotbow/interestingfish/FishInfoFactory.java
+++ b/src/main/java/net/shotbow/interestingfish/FishInfoFactory.java
@@ -1,5 +1,7 @@
 package net.shotbow.interestingfish;
 
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.shotbow.interestingfish.config.InterestingConfig;
 import net.shotbow.interestingfish.objects.Breed;
 import net.shotbow.interestingfish.objects.Descriptor;
@@ -29,6 +31,9 @@ public class FishInfoFactory
     private Random random = new Random();
     private InterestingConfig config;
 
+    private final MiniMessage miniMessage = MiniMessage.get();
+    private final LegacyComponentSerializer legacyHexSerializer = LegacyComponentSerializer.builder().hexColors().useUnusualXRepeatedCharacterHexFormat().build();
+
     public FishInfoFactory(InterestingConfig config)
     {
         this.config = config;
@@ -55,20 +60,20 @@ public class FishInfoFactory
         if (random.nextInt(100) < config.percentDescriptorChance)
         {
             Descriptor descriptor = descriptorIndex.get(weightedDescriptors.get(random.nextInt(weightedDescriptors.size())));
-            nameBuilder.append(replaceColorChars(descriptor.getText())).append(" ");
+            nameBuilder.append(parseColors(descriptor.getText())).append(ChatColor.RESET).append(" ");
             weight += descriptor.getMinWeightModifier() + random.nextDouble() * descriptor.getMaxWeightModifier() - descriptor.getMinWeightModifier();
         }
         Breed breed = breedIndex.get(weightedBreeds.get(random.nextInt(weightedBreeds.size())));
         weight += breed.getMinWeightModifier() + random.nextDouble() * breed.getMaxWeightModifier() - breed.getMinWeightModifier();
-        nameBuilder.append(replaceColorChars(breed.getText()));
+        nameBuilder.append(parseColors(breed.getText()));
         if (weight < config.minWeight)
             weight = config.minWeight;
         return new FishInfo(nameBuilder.toString(), weight);
     }
 
-    private String replaceColorChars(String text)
+    public String parseColors(String text)
     {
-        return text.replace('&', ChatColor.COLOR_CHAR);
+        return legacyHexSerializer.serialize(miniMessage.parse(text.replace('&', ChatColor.COLOR_CHAR)));
     }
 
 }

--- a/src/main/java/net/shotbow/interestingfish/config/InterestingConfig.java
+++ b/src/main/java/net/shotbow/interestingfish/config/InterestingConfig.java
@@ -24,12 +24,12 @@ public class InterestingConfig extends ConfigObject
     public boolean requireLuckEnchant = false;
     public boolean excludeLuckEnchant = false;
     public boolean showItemFrameInfo = true;
-    public String weightLabel = "&bWeight: &f";
+    public String weightLabel = "<aqua>Weight: <white>";
     public String weightUnit = "lbs";
-    public String caughtByLabel = "&6Caught by: &f";
+    public String caughtByLabel = "<gold>Caught by: <white>";
     public boolean caughtByNickname = false;
-    public String dateLabel = "&6";
-    public String dateFormat = "MM/dd/yy hh:mm";
+    public String dateLabel = "<gold>";
+    public String dateFormat = "M/d/yy h:mm aa";
     public List<HashMap<String, Object>> descriptorList = new ArrayList<HashMap<String, Object>>()
     {{
         add(new HashMap<String, Object>()
@@ -37,14 +37,35 @@ public class InterestingConfig extends ConfigObject
             put("minWeightModifier", 5.0);
             put("maxWeightModifier", 20.0);
             put("rollWeight", 1);
-            put("text", "&aBig");
+            put("text", "<green><bold>Big");
         }});
         add(new HashMap<String, Object>()
         {{
             put("minWeightModifier", -20.0);
             put("maxWeightModifier", 0.0);
             put("rollWeight", 1);
-            put("text", "&aTiny");
+            put("text", "<green><italic>Tiny");
+        }});
+        add(new HashMap<String, Object>()
+        {{
+            put("minWeightModifier", 1.0);
+            put("maxWeightModifier", 100.0);
+            put("rollWeight", 1);
+            put("text", "<color:#4B0082>Kyori");
+        }});
+        add(new HashMap<String, Object>()
+        {{
+            put("minWeightModifier", 1.0);
+            put("maxWeightModifier", 100.0);
+            put("rollWeight", 1);
+            put("text", "<rainbow>Rainbow");
+        }});
+        add(new HashMap<String, Object>()
+        {{
+            put("minWeightModifier", 1.0);
+            put("maxWeightModifier", 100.0);
+            put("rollWeight", 1);
+            put("text", "<gradient:purple:blue><underlined>Adventurous");
         }});
     }};
     public List<HashMap<String, Object>> breedsList = new ArrayList<HashMap<String, Object>>()
@@ -54,14 +75,14 @@ public class InterestingConfig extends ConfigObject
             put("minWeightModifier", 1.0);
             put("maxWeightModifier", 20.0);
             put("rollWeight", 1);
-            put("text", "Trout");
+            put("text", "<yellow>Trout");
         }});
         add(new HashMap<String, Object>()
         {{
             put("minWeightModifier", 20.0);
             put("maxWeightModifier", 50.0);
             put("rollWeight", 1);
-            put("text", "Tuna");
+            put("text", "<aqua>Tuna");
         }});
     }};
 

--- a/src/main/java/net/shotbow/interestingfish/listeners/FishListener.java
+++ b/src/main/java/net/shotbow/interestingfish/listeners/FishListener.java
@@ -4,7 +4,6 @@ import net.shotbow.interestingfish.FishInfoFactory;
 import net.shotbow.interestingfish.config.InterestingConfig;
 import net.shotbow.interestingfish.objects.FishInfo;
 import net.shotbow.interestingfish.utility.ItemUtility;
-import org.bukkit.ChatColor;
 import org.bukkit.Tag;
 import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
@@ -56,17 +55,11 @@ public class FishListener implements Listener
                 ItemUtility.renameItem(fish, fishInfo.getName());
                 ItemUtility.setLore(fish, new ArrayList<String>()
                 {{
-                    add(replaceColorChars(config.weightLabel) + decimalFormat.format(fishInfo.getWeight()) + replaceColorChars(config.weightUnit));
-                    add(replaceColorChars(config.caughtByLabel) + name);
-                    add(replaceColorChars(config.dateLabel) + dateFormat.format(new Date()));
+                    add(fishInfoFactory.parseColors(config.weightLabel + decimalFormat.format(fishInfo.getWeight()) + config.weightUnit));
+                    add(fishInfoFactory.parseColors(config.caughtByLabel + name));
+                    add(fishInfoFactory.parseColors(config.dateLabel + dateFormat.format(new Date())));
                 }});
             }
         }
-    }
-
-
-    private String replaceColorChars(String text)
-    {
-        return text.replace('&', ChatColor.COLOR_CHAR);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,4 +4,4 @@ version: "${project.version}"
 api-version: "1.13"
 authors: ["lazertester", "Puremin0rez"]
 website: "https://github.com/Puremin0rez/InterestingFish"
-description: "InterestingFish, gives fishes names and weight."
+description: "Allow your players to catch fish with style - adds fancy names, weights and catch information to caught fish. "


### PR DESCRIPTION
This adds MiniMessage support to the entire configuration file, allowing you to easily specify colors and do other cool features like gradients and full hex support. 

Refer to https://docs.adventure.kyori.net/minimessage.html for documentation on the syntax. 

Using ampersand is still supported for users who prefer that, or have old configuration files.

This was done with very minimal effort as doing proper support (with full validation, etc) would require larger refactor & general code maintenance, which I am not willing to do with this ancient forked code base.